### PR TITLE
Fix Queue import in view module

### DIFF
--- a/galley/view.py
+++ b/galley/view.py
@@ -4,7 +4,7 @@
 This is the "View" of the MVC world.
 """
 import os
-from queue import Query, Empty
+from queue import Queue, Empty
 import threading
 from tkinter import *
 from tkinter.font import *
@@ -639,4 +639,3 @@ class MainWindow(object):
                 self.project_file_tree.selection_set(index_filename)
             else:
                 tkMessageBox.showerror(message="Couldn't find %s" % self.filename_normalizer(filename))
-

--- a/tests/test_view_imports.py
+++ b/tests/test_view_imports.py
@@ -1,0 +1,21 @@
+import ast
+import unittest
+from pathlib import Path
+
+
+VIEW_PY = Path(__file__).parents[1] / "galley" / "view.py"
+
+
+class ViewImportTests(unittest.TestCase):
+    def test_view_imports_queue_class(self):
+        module = ast.parse(VIEW_PY.read_text(encoding="utf-8"))
+        queue_imports = {
+            alias.name
+            for node in module.body
+            if isinstance(node, ast.ImportFrom) and node.module == "queue"
+            for alias in node.names
+        }
+
+        self.assertIn("Queue", queue_imports)
+        self.assertIn("Empty", queue_imports)
+        self.assertNotIn("Query", queue_imports)


### PR DESCRIPTION
## Summary

- Fix the startup import in `galley.view` by importing `Queue` from the standard library `queue` module instead of the non-existent `Query` symbol.
- Add a small regression test that checks the view module imports the queue symbols it uses.

Closes #15.

## Verification

- `python3.14 -m unittest tests.test_view_imports` failed before the import fix with `Queue` missing and passes after it.
- `venv/bin/python -m unittest discover`
- `venv/bin/python -c 'import galley.view; print(galley.view.Queue.__name__, galley.view.Empty.__name__)'`
- `git diff --check`

Note: the import smoke check emits an existing SyntaxWarning from `galley/widgets.py` about `is` with a string literal; this PR does not touch that file.

Assisted-by: OpenAI Codex
